### PR TITLE
Add secondary sorting by unique IDs to prevent random ordering

### DIFF
--- a/app/services/db_service.py
+++ b/app/services/db_service.py
@@ -118,7 +118,7 @@ class DatabaseService:
                 query = f"""
                     SELECT * FROM atp.training
                     {where_clause}
-                    ORDER BY {sort_by} {sort_order}
+                    ORDER BY {sort_by} {sort_order}, imdb_id DESC
                     LIMIT %s OFFSET %s
                 """
 
@@ -240,7 +240,7 @@ class DatabaseService:
                         created_at, updated_at
                     FROM atp.media
                     WHERE {where_clause}
-                    ORDER BY {sort_by} {sort_order}
+                    ORDER BY {sort_by} {sort_order}, hash DESC
                     LIMIT %s OFFSET %s
                 """
                 


### PR DESCRIPTION
- Training table: ORDER BY primary_field, imdb_id DESC
- Media table: ORDER BY primary_field, hash DESC
- Prevents shuffling when multiple records have identical primary sort values

🤖 Generated with [Claude Code](https://claude.ai/code)